### PR TITLE
Add AppEngine integration instructions to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,3 +102,82 @@ Always use ``@line_profile`` as the inner-most decorator.
 
 .. _`flask_debugtoolbar`: https://github.com/mgood/flask-debugtoolbar
 .. _`line_profiler`: https://github.com/certik/line_profiler
+
+
+Using line_profiler with the Google AppEngine SDK
+-------------------------------------------------
+
+``line_profiler`` is implemented as a C extension.  Unfortunately, AppEngine does not support C extensions in the cloud, and ``dev_appserver`` simulates this restriction on your local machine.  If you'd like to use ``line_profiler`` on your local machine, you can monkey-patch the AppEngine SDK to permit it.  The Flask-DebugToolbar will make sure this plugin is disabled in production (it will catch any ImportErrors and disable the affected panel).
+
+Simply open ``application/__init__.py``, which should look something like this:
+
+::
+from __future__ import absolute_import
+
+from flask import Flask
+
+app = Flask('application')
+app.config.from_object('application.settings')
+
+if app.config['DEBUG']:
+    from werkzeug.debug import DebuggedApplication
+    
+    app.wsgi_app = DebuggedApplication(app.wsgi_app, evalex=True)
+
+
+    from flask.ext.debugtoolbar import DebugToolbarExtension
+    
+    toolbar = DebugToolbarExtension(app)
+
+
+import application.urls
+
+::
+
+and insert the monkey-patch, like so:
+
+::
+from __future__ import absolute_import
+
+from flask import Flask
+
+app = Flask('application')
+app.config.from_object('application.settings')
+
+if app.config['DEBUG']:
+    from werkzeug.debug import DebuggedApplication
+    
+    app.wsgi_app = DebuggedApplication(app.wsgi_app, evalex=True)
+
+
+    # We can't use LineProfiler in production because it requires a C-extension,
+    # but we can monkey-patch it in here for use on the dev server:
+    try:
+        import os, sys, re
+
+        if 'SERVER_SOFTWARE' in os.environ and os.environ['SERVER_SOFTWARE'].startswith('Dev'):
+            # white-list the line_profiler C extension
+            sys.meta_path[3]._enabled_regexes.append(re.compile(r'.*line_profiler.*'))
+
+            from flask_debugtoolbar_lineprofilerpanel.profile import line_profile
+
+
+            # import the methods you want to profile here, and whitelist them with line_profile:
+            #from application.views import YourViewClass
+            #
+            #line_profile(YourViewClass.the_method_you_want_to_profile)
+            #line_profile(YourViewClass.another_method_you_want_to_profile)
+    except:
+        pass
+    
+
+    # Make sure the monkey-patch is applied before you instantiate the DebugToolbarExtension.
+    from flask.ext.debugtoolbar import DebugToolbarExtension
+    
+    toolbar = DebugToolbarExtension(app)
+
+
+import application.urls
+
+::
+

--- a/README.rst
+++ b/README.rst
@@ -109,75 +109,72 @@ Using line_profiler with the Google AppEngine SDK
 
 ``line_profiler`` is implemented as a C extension.  Unfortunately, AppEngine does not support C extensions in the cloud, and ``dev_appserver`` simulates this restriction on your local machine.  If you'd like to use ``line_profiler`` on your local machine, you can monkey-patch the AppEngine SDK to permit it.  The Flask-DebugToolbar will make sure this plugin is disabled in production (it will catch any ImportErrors and disable the affected panel).
 
-Simply open ``application/__init__.py``, which should look something like this:
-
-::
-from __future__ import absolute_import
-
-from flask import Flask
-
-app = Flask('application')
-app.config.from_object('application.settings')
-
-if app.config['DEBUG']:
-    from werkzeug.debug import DebuggedApplication
+Simply open ``application/__init__.py``, which should look something like this::
     
-    app.wsgi_app = DebuggedApplication(app.wsgi_app, evalex=True)
+    from __future__ import absolute_import
 
+    from flask import Flask
 
-    from flask.ext.debugtoolbar import DebugToolbarExtension
+    app = Flask('application')
+    app.config.from_object('application.settings')
+
+    if app.config['DEBUG']:
+        from werkzeug.debug import DebuggedApplication
     
-    toolbar = DebugToolbarExtension(app)
+        app.wsgi_app = DebuggedApplication(app.wsgi_app, evalex=True)
 
 
-import application.urls
+        from flask.ext.debugtoolbar import DebugToolbarExtension
+    
+        toolbar = DebugToolbarExtension(app)
 
-::
+
+    import application.urls
+
 
 and insert the monkey-patch, like so:
 
-::
-from __future__ import absolute_import
-
-from flask import Flask
-
-app = Flask('application')
-app.config.from_object('application.settings')
-
-if app.config['DEBUG']:
-    from werkzeug.debug import DebuggedApplication
-    
-    app.wsgi_app = DebuggedApplication(app.wsgi_app, evalex=True)
-
-
-    # We can't use LineProfiler in production because it requires a C-extension,
-    # but we can monkey-patch it in here for use on the dev server:
-    try:
-        import os, sys, re
-
-        if 'SERVER_SOFTWARE' in os.environ and os.environ['SERVER_SOFTWARE'].startswith('Dev'):
-            # white-list the line_profiler C extension
-            sys.meta_path[3]._enabled_regexes.append(re.compile(r'.*line_profiler.*'))
-
-            from flask_debugtoolbar_lineprofilerpanel.profile import line_profile
-
-
-            # import the methods you want to profile here, and whitelist them with line_profile:
-            #from application.views import YourViewClass
-            #
-            #line_profile(YourViewClass.the_method_you_want_to_profile)
-            #line_profile(YourViewClass.another_method_you_want_to_profile)
-    except:
-        pass
-    
-
-    # Make sure the monkey-patch is applied before you instantiate the DebugToolbarExtension.
-    from flask.ext.debugtoolbar import DebugToolbarExtension
-    
-    toolbar = DebugToolbarExtension(app)
-
-
-import application.urls
 
 ::
 
+    from __future__ import absolute_import
+
+    from flask import Flask
+
+    app = Flask('application')
+    app.config.from_object('application.settings')
+
+    if app.config['DEBUG']:
+        from werkzeug.debug import DebuggedApplication
+    
+        app.wsgi_app = DebuggedApplication(app.wsgi_app, evalex=True)
+
+
+        # We can't use LineProfiler in production because it requires a C-extension,
+        # but we can monkey-patch it in here for use on the dev server:
+        try:
+            import os, sys, re
+
+            if 'SERVER_SOFTWARE' in os.environ and os.environ['SERVER_SOFTWARE'].startswith('Dev'):
+                # white-list the line_profiler C extension
+                sys.meta_path[3]._enabled_regexes.append(re.compile(r'.*line_profiler.*'))
+
+                from flask_debugtoolbar_lineprofilerpanel.profile import line_profile
+
+
+                # import the methods you want to profile here, and whitelist them with line_profile:
+                #from application.views import YourViewClass
+                #
+                #line_profile(YourViewClass.the_method_you_want_to_profile)
+                #line_profile(YourViewClass.another_method_you_want_to_profile)
+        except:
+            pass
+    
+
+        # Make sure the monkey-patch is applied before you instantiate the DebugToolbarExtension.
+        from flask.ext.debugtoolbar import DebugToolbarExtension
+    
+        toolbar = DebugToolbarExtension(app)
+
+
+    import application.urls

--- a/README.rst
+++ b/README.rst
@@ -162,7 +162,7 @@ and insert the monkey-patch, like so:
                 from flask_debugtoolbar_lineprofilerpanel.profile import line_profile
 
 
-                # import the methods you want to profile here, and whitelist them with line_profile:
+                ## import the methods you want to profile here, and whitelist them with line_profile:
                 #from application.views import YourViewClass
                 #
                 #line_profile(YourViewClass.the_method_you_want_to_profile)

--- a/flask_debugtoolbar_lineprofilerpanel/templates/content.html
+++ b/flask_debugtoolbar_lineprofilerpanel/templates/content.html
@@ -85,7 +85,7 @@
         </table>
     {% endfor %}
 {% endif %}
-    <h3> Usage Instructinos </h3>
+    <h3> Usage Instructions </h3>
 
 <pre>
 from flask_debugtoolbar_lineprofilerpanel.profile import line_profile


### PR DESCRIPTION
Usage Instructions is misspelled.
